### PR TITLE
Launch NEPs Website

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,7 +16,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'cla.json'
-          url-to-cladocument: 'https://raw.githubusercontent.com/newtonproject/NEPs/master/cla.md'
+          url-to-cladocument: 'https://neps.newtonproject.org/cla'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
           allowlist: ''

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.web/public
-          cname: neps.newton.bio
+          cname: neps.newtonproject.org

--- a/.web/config.yaml
+++ b/.web/config.yaml
@@ -1,4 +1,4 @@
-baseURL: https://neps.newton.bio/
+baseURL: https://neps.newtonproject.org/
 title: Newton Evolution Proposals (NEPs)
 theme: newdocs
 

--- a/NEPS/nep-template-nrc/index.md
+++ b/NEPS/nep-template-nrc/index.md
@@ -16,8 +16,8 @@ This is the suggested template for new NRC type NEP.
 Start edit by copy this template folder to /NEPS/nep-x/
 
 Note: the NEP number will be assigned by an editor when opening a pull request to submit your NEP.
-Guides: https://neps.newton.bio/guides/
-Format & Front Matter: https://neps.newton.bio/guides/format/
+Guides: https://neps.newtonproject.org/guides/
+Format & Front Matter: https://neps.newtonproject.org/guides/format/
 
 -->
 

--- a/NEPS/nep-template/index.md
+++ b/NEPS/nep-template/index.md
@@ -15,8 +15,8 @@ This is the standard template for new NEP.
 Start edit by copy this template folder to /NEPS/nep-x/
 
 Note: the NEP number will be assigned by an editor when opening a pull request to submit your NEP.
-Guides: https://neps.newton.bio/guides/
-Format & Front Matter: https://neps.newton.bio/guides/format/
+Guides: https://neps.newtonproject.org/guides/
+Format & Front Matter: https://neps.newtonproject.org/guides/format/
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ We welcome anyone with suggestions related to Newton Project to compile a NEP.
 
 This repository tracks the ongoing status of NEPs.
 
-- [NEPs Official Website](https://neps.newton.bio/) are build from NEPs and Docs from this repository.
+- [NEPs Official Website](https://neps.newtonproject.org/) are build from NEPs and Docs from this repository.
 
-- [All NEPs](https://neps.newton.bio/neps/) of all NEPs merged in to this repository.
+- [All NEPs](https://neps.newtonproject.org/neps/) of all NEPs merged in to this repository.
 
-- [NEP Process](https://neps.newton.bio/guides/nep-process/) that governs the NEPs repository.
+- [NEP Process](https://neps.newtonproject.org/guides/nep-process/) that governs the NEPs repository.
 
 ## Contributing to NEPs
 
 Newton Evolution Proposals (NEPs) repository exists as a place to share concrete proposals with potential users of the proposal and the Newton community at large.
 
-Visit [NEP Guidelines](https://neps.newton.bio/guides/) to learn how to contribute to NEPs.
+Visit [NEP Guidelines](https://neps.newtonproject.org/guides/) to learn how to contribute to NEPs.
 
 Docs for Guides are located in `./guides` directory in this repository.
 


### PR DESCRIPTION
This will launch NEPS website on neps.newtonproject.org according to #38

Major changes happened to NEPs repo for #38:

- All following changes based on 1d584068f699eb993fedbe3cbd6b4ca5ade1cc61
- NEPs files renamed: 8a1fbf1d7dae63e5d4566042a379cc7b78607e2b
- NEPs auxiliary files moved: a0d0c7133fb2c1dc35a8fec0ec314a361104181b
- NEPs Front Matter updated: d88837039debe62c301c4306130c46bfc59c86d3
- Links in NEPs files updated: 54d617f92df7f0db9fdac18541ec9e840711912f
- NEPs Markdown format updated: 3f61557564652e32fae3227e35793901fb69c554
- Reviews files updated: fd5bbaaa8a5e4b2201d1eae2bf611e7f360e387a
- Website theme added: 1e4dc64af5d7ba0b7792931b1b93d4f5fb486469
- Website codes and related files added and updated: 
  - update CLA doc: 7b082de02a095b49e804faf0fa1c05ee5fc8a01d
  - add guides docs: bf4dc7446237ea1ba2db37bb814496e51251de2e
  - init website configs: c7023aea7bdac5a2a2c72d8e505bb22c04d898f5
  - Add Github Actions for Format Check, Build Test and Deploy: 65b175dc5cedf021b55e160e236f427ccbfa85dc
  - update README, add CC0 license: 099fc27cb86111c4a67293525c03acb5617db7f2
  - add nep templates: 99f7b4bad61e05c041573a2fba71306d44b482c8
  - update guides doc: 5ecd614532c4daef406a8d6ecfdbfaa78f2daf59
  - update README: 6cd480ce34a9536b925a9308ea5534ea7a8b4f8a
